### PR TITLE
Use shared libraries as SDK compilation artifacts

### DIFF
--- a/applications/_libs/gpu_decode/CMakeLists.txt
+++ b/applications/_libs/gpu_decode/CMakeLists.txt
@@ -8,7 +8,7 @@ set(GPU_DECODE_SRC
   gpu_decode.h
 )
 
-add_library(CMP_GpuDecode STATIC ${GPU_DECODE_H} ${GPU_DECODE_SRC})
+add_library(CMP_GpuDecode SHARED ${GPU_DECODE_H} ${GPU_DECODE_SRC})
 
 target_include_directories(CMP_GpuDecode PRIVATE
     ${PROJECT_SOURCE_DIR}/applications/_plugins/common

--- a/applications/_plugins/cimage/dds/CMakeLists.txt
+++ b/applications/_plugins/cimage/dds/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-add_library(Image_DDS STATIC "")
+add_library(Image_DDS SHARED "")
 
 target_sources(Image_DDS 
     PRIVATE

--- a/applications/_plugins/cimage/exr/CMakeLists.txt
+++ b/applications/_plugins/cimage/exr/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-add_library(Image_EXR STATIC "")
+add_library(Image_EXR SHARED "")
 
 target_sources(Image_EXR
     PRIVATE

--- a/applications/_plugins/cimage/ktx/CMakeLists.txt
+++ b/applications/_plugins/cimage/ktx/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-add_library(Image_KTX STATIC "")
+add_library(Image_KTX SHARED "")
 
 # Enabled KTX1 Only
 file(GLOB_RECURSE KTX_Lib

--- a/applications/_plugins/cimage/ktx2/CMakeLists.txt
+++ b/applications/_plugins/cimage/ktx2/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-add_library(Image_KTX2 STATIC "")
+add_library(Image_KTX2 SHARED "")
 
 target_sources(Image_KTX2
     PRIVATE

--- a/applications/_plugins/cimage/tga/CMakeLists.txt
+++ b/applications/_plugins/cimage/tga/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-add_library(Image_TGA STATIC "")
+add_library(Image_TGA SHARED "")
 
 target_sources(Image_TGA
     PRIVATE

--- a/applications/_plugins/common/CMakeLists.txt
+++ b/applications/_plugins/common/CMakeLists.txt
@@ -60,7 +60,7 @@ if (OPTION_BUILD_EXR)
     list(APPEND PLUGIN_COMMON_H   cexr.h)
 endif()
 
-add_library(CMP_Common STATIC 
+add_library(CMP_Common SHARED
     ${PLUGIN_COMMON_SRC} 
     ${PLUGIN_COMMON_SRC_QT}
     ${PLUGIN_COMMON_H}

--- a/cmp_compressonatorlib/CMakeLists.txt
+++ b/cmp_compressonatorlib/CMakeLists.txt
@@ -68,7 +68,7 @@ if (OPTION_BUILD_BROTLIG)
 endif()
 
 add_library(CMP_Compressonator 
-    STATIC  
+    SHARED
     version.h
     common.h
     compress.cpp

--- a/cmp_core/CMakeLists.txt
+++ b/cmp_core/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-add_library(CMP_Core STATIC)
+add_library(CMP_Core SHARED)
 
 target_sources(CMP_Core
     PRIVATE
@@ -67,7 +67,7 @@ set_target_properties(CMP_Core PROPERTIES FOLDER ${PROJECT_FOLDER_SDK_LIBS})
 # Core SIMD options
 
 # SSE
-add_library(CMP_Core_SSE STATIC)
+add_library(CMP_Core_SSE SHARED)
 target_sources(CMP_Core_SSE PRIVATE source/core_simd_sse.cpp)
 target_include_directories(CMP_Core_SSE PRIVATE source shaders)
 
@@ -78,7 +78,7 @@ endif()
 set_target_properties(CMP_Core_SSE PROPERTIES FOLDER ${PROJECT_FOLDER_SDK_LIBS})
 
 # AVX
-add_library(CMP_Core_AVX STATIC)
+add_library(CMP_Core_AVX SHARED)
 target_sources(CMP_Core_AVX PRIVATE source/core_simd_avx.cpp)
 target_include_directories(CMP_Core_AVX PRIVATE source shaders)
 
@@ -91,7 +91,7 @@ endif()
 set_target_properties(CMP_Core_AVX PROPERTIES FOLDER ${PROJECT_FOLDER_SDK_LIBS})
 
 # AVX-512
-add_library(CMP_Core_AVX512 STATIC)
+add_library(CMP_Core_AVX512 SHARED)
 target_sources(CMP_Core_AVX512 PRIVATE source/core_simd_avx512.cpp)
 target_include_directories(CMP_Core_AVX512 PRIVATE source shaders)
 

--- a/cmp_framework/CMakeLists.txt
+++ b/cmp_framework/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-add_library(CMP_Framework STATIC "")
+add_library(CMP_Framework SHARED "")
 
 
 if(CMP_HOST_WINDOWS)


### PR DESCRIPTION
By default, this repo builds static libraries. There is an option -DBUILD_SHARED_LIBS that changes nothing about this, despite the name. Resonite only needs the SDK from this library, and it needs it as shared libraries (for interop with Compressonator.NET. As such, this patch is to made cmake build shared libraries by default rather than static libraries, as to my knowledge there is no way to have an option flag that builds static libraries--you have to modify the cmake files.

This is required for #1 / https://github.com/Yellow-Dog-Man/Compressonator.NET/issues/8