### PR TITLE
CI/CD builds for libraries on Linux + Windows

### DIFF
--- a/.github/workflows/build-ydms.yaml
+++ b/.github/workflows/build-ydms.yaml
@@ -1,0 +1,33 @@
+name: "YDMS Build"
+
+on: [push]
+
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set dist name
+        run: |
+          echo "wps=${{ github.workspace }}/builddir" >> "$GITHUB_ENV"
+          mkdir -p ${{ github.workspace }}/builddir
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mesa-common-dev libglew-dev libicu-dev libegl1-mesa-dev libopenexr-dev libopencv-dev libglm-dev
+      - name: Generate build files
+        working-directory: ${{ env.wps }}
+        run: |
+          cmake -DOPTION_ENABLE_ALL_APPS=OFF -DOPTION_BUILD_CMP_SDK=ON -DOPTION_CMP_QT=OFF -DOPTION_BUILD_KTX2=ON -DOPTION_BUILD_EXR=ON -DOPTION_BUILD_GUI=OFF -DBUILD_SHARED_LIBS=ON ..
+      - name: Build library
+        working-directory: ${{ env.wps }}
+        run: |
+          CPLUS_INCLUDE_PATH=/usr/include/opencv4/ make -j4
+          tree ${{ github.workspace }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-lib
+          path: ${{ env.wps }}/lib/**/*.so

--- a/.github/workflows/build-ydms.yaml
+++ b/.github/workflows/build-ydms.yaml
@@ -25,9 +25,33 @@ jobs:
         working-directory: ${{ env.wps }}
         run: |
           CPLUS_INCLUDE_PATH=/usr/include/opencv4/ make -j4
-          tree ${{ github.workspace }}
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
           name: linux-lib
           path: ${{ env.wps }}/lib/**/*.so
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup cmake
+        run: |
+          cmake -E make_directory ${{ github.workspace }}/build/bin
+          python build/fetch_dependencies.py
+      - name: Setup msbuild
+        uses: microsoft/setup-msbuild@v2
+      - name: Build compressonator
+        run: |
+          msbuild -target:build -property:Configuration=Release_MD_DLL -property:Platform=x64 -m build_sdk\cmp_framework.sln
+          msbuild -target:build -property:Configuration=Release_MD_DLL -property:Platform=x64 -m build_sdk\cmp_compressonatorlib.sln
+      - name: Collect build results
+        shell: bash
+        run: |
+          mkdir results
+          cp build/Release*/x64/{*.lib,*.dll} results
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-lib
+          path: results/

--- a/applications/_libs/gpu_decode/CMakeLists.txt
+++ b/applications/_libs/gpu_decode/CMakeLists.txt
@@ -8,7 +8,7 @@ set(GPU_DECODE_SRC
   gpu_decode.h
 )
 
-add_library(CMP_GpuDecode STATIC ${GPU_DECODE_H} ${GPU_DECODE_SRC})
+add_library(CMP_GpuDecode SHARED ${GPU_DECODE_H} ${GPU_DECODE_SRC})
 
 target_include_directories(CMP_GpuDecode PRIVATE
     ${PROJECT_SOURCE_DIR}/applications/_plugins/common

--- a/applications/_plugins/cimage/dds/CMakeLists.txt
+++ b/applications/_plugins/cimage/dds/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-add_library(Image_DDS STATIC "")
+add_library(Image_DDS SHARED "")
 
 target_sources(Image_DDS 
     PRIVATE

--- a/applications/_plugins/cimage/exr/CMakeLists.txt
+++ b/applications/_plugins/cimage/exr/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-add_library(Image_EXR STATIC "")
+add_library(Image_EXR SHARED "")
 
 target_sources(Image_EXR
     PRIVATE

--- a/applications/_plugins/cimage/ktx/CMakeLists.txt
+++ b/applications/_plugins/cimage/ktx/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-add_library(Image_KTX STATIC "")
+add_library(Image_KTX SHARED "")
 
 # Enabled KTX1 Only
 file(GLOB_RECURSE KTX_Lib

--- a/applications/_plugins/cimage/ktx2/CMakeLists.txt
+++ b/applications/_plugins/cimage/ktx2/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-add_library(Image_KTX2 STATIC "")
+add_library(Image_KTX2 SHARED "")
 
 target_sources(Image_KTX2
     PRIVATE

--- a/applications/_plugins/cimage/tga/CMakeLists.txt
+++ b/applications/_plugins/cimage/tga/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-add_library(Image_TGA STATIC "")
+add_library(Image_TGA SHARED "")
 
 target_sources(Image_TGA
     PRIVATE

--- a/applications/_plugins/common/CMakeLists.txt
+++ b/applications/_plugins/common/CMakeLists.txt
@@ -60,7 +60,7 @@ if (OPTION_BUILD_EXR)
     list(APPEND PLUGIN_COMMON_H   cexr.h)
 endif()
 
-add_library(CMP_Common STATIC 
+add_library(CMP_Common SHARED
     ${PLUGIN_COMMON_SRC} 
     ${PLUGIN_COMMON_SRC_QT}
     ${PLUGIN_COMMON_H}

--- a/cmp_compressonatorlib/CMakeLists.txt
+++ b/cmp_compressonatorlib/CMakeLists.txt
@@ -68,7 +68,7 @@ if (OPTION_BUILD_BROTLIG)
 endif()
 
 add_library(CMP_Compressonator 
-    STATIC  
+    SHARED
     version.h
     common.h
     compress.cpp

--- a/cmp_core/CMakeLists.txt
+++ b/cmp_core/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-add_library(CMP_Core STATIC)
+add_library(CMP_Core SHARED)
 
 target_sources(CMP_Core
     PRIVATE
@@ -67,7 +67,7 @@ set_target_properties(CMP_Core PROPERTIES FOLDER ${PROJECT_FOLDER_SDK_LIBS})
 # Core SIMD options
 
 # SSE
-add_library(CMP_Core_SSE STATIC)
+add_library(CMP_Core_SSE SHARED)
 target_sources(CMP_Core_SSE PRIVATE source/core_simd_sse.cpp)
 target_include_directories(CMP_Core_SSE PRIVATE source shaders)
 
@@ -78,7 +78,7 @@ endif()
 set_target_properties(CMP_Core_SSE PROPERTIES FOLDER ${PROJECT_FOLDER_SDK_LIBS})
 
 # AVX
-add_library(CMP_Core_AVX STATIC)
+add_library(CMP_Core_AVX SHARED)
 target_sources(CMP_Core_AVX PRIVATE source/core_simd_avx.cpp)
 target_include_directories(CMP_Core_AVX PRIVATE source shaders)
 
@@ -91,7 +91,7 @@ endif()
 set_target_properties(CMP_Core_AVX PROPERTIES FOLDER ${PROJECT_FOLDER_SDK_LIBS})
 
 # AVX-512
-add_library(CMP_Core_AVX512 STATIC)
+add_library(CMP_Core_AVX512 SHARED)
 target_sources(CMP_Core_AVX512 PRIVATE source/core_simd_avx512.cpp)
 target_include_directories(CMP_Core_AVX512 PRIVATE source shaders)
 

--- a/cmp_framework/CMakeLists.txt
+++ b/cmp_framework/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-add_library(CMP_Framework STATIC "")
+add_library(CMP_Framework SHARED "")
 
 
 if(CMP_HOST_WINDOWS)


### PR DESCRIPTION
This PR adds:
- Native Linux builds
  - Massive thanks to @yoshiyoshyosh for figuring out the building part which made this PR especially easy (make sure to accept #2 before accepting this one, even though this PR is rebased on that branch already)
  - Currently only builds for x64 given the ARM build has some issues with a `march` parameter set in some places
  - Uploads an artifact named `linux-lib`
- Native Windows builds
  - This was fairly straightforward, most of the work was already done within the existing CI/CD, just had to trim it a little
  - Uploads an artifact named `windows-lib`

Proofs:
- Linux workflow run: https://github.com/jae1911/compressonator-ydms/actions/runs/13015559941/job/36303774157
- Windows workflow run: https://github.com/jae1911/compressonator-ydms/actions/runs/13015559941/job/36303774697

If you cannot download the artifacts, try going to the parent run and they should be displayed there.

Needs #2
Fixes #1 