### PR TITLE
fix(CMP_ConvertTexture): Correct error code from CMP_ConvertTexture

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -44,7 +44,7 @@ jobs:
       run: cmake --build . --config $BUILD_TYPE
 
     - name: Upload Build Artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with: 
           name: CompressonatorCLI_64_Windows_Master_Build
           path: ${{github.workspace}}/build/bin/bin/Release
@@ -134,7 +134,7 @@ jobs:
 
       # Will probably want to collect the files into a better structure before running this command
       - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with: 
           name: CompressonatorFramework_Windows_Master_Build
           path: CompressonatorFramework_result/

--- a/cmp_compressonatorlib/compressonator.cpp
+++ b/cmp_compressonatorlib/compressonator.cpp
@@ -308,7 +308,7 @@ CMP_ERROR CMP_API CMP_ConvertTexture(CMP_Texture*               pSourceTexture,
     CodecType destType = GetCodecType(pDestTexture->format);
     assert(destType != CT_Unknown);
     if (destType == CT_Unknown)
-        return CMP_ERR_UNSUPPORTED_SOURCE_FORMAT;
+        return CMP_ERR_UNSUPPORTED_DEST_FORMAT;
 
     // Figure out the type of processing we are doing
 


### PR DESCRIPTION
CMP_ERR_UNSUPPORTED_SOURCE_FORMAT was returned when the Destination Format had an unsupported codec. This should be DEST_FORMAT

Same as: https://github.com/GPUOpen-Tools/compressonator/pull/337

but for our fork, which can test ci.