### PR TITLE
Restructure Resultant shared object files to contain their detendies.

### DIFF
--- a/applications/_libs/gpu_decode/CMakeLists.txt
+++ b/applications/_libs/gpu_decode/CMakeLists.txt
@@ -8,7 +8,7 @@ set(GPU_DECODE_SRC
   gpu_decode.h
 )
 
-add_library(CMP_GpuDecode SHARED ${GPU_DECODE_H} ${GPU_DECODE_SRC})
+add_library(CMP_GpuDecode STATIC ${GPU_DECODE_H} ${GPU_DECODE_SRC})
 
 target_include_directories(CMP_GpuDecode PRIVATE
     ${PROJECT_SOURCE_DIR}/applications/_plugins/common

--- a/applications/_plugins/cimage/dds/CMakeLists.txt
+++ b/applications/_plugins/cimage/dds/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-add_library(Image_DDS SHARED "")
+add_library(Image_DDS STATIC "")
 
 target_sources(Image_DDS 
     PRIVATE

--- a/applications/_plugins/cimage/exr/CMakeLists.txt
+++ b/applications/_plugins/cimage/exr/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-add_library(Image_EXR SHARED "")
+add_library(Image_EXR STATIC "")
 
 target_sources(Image_EXR
     PRIVATE

--- a/applications/_plugins/cimage/ktx/CMakeLists.txt
+++ b/applications/_plugins/cimage/ktx/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-add_library(Image_KTX SHARED "")
+add_library(Image_KTX STATIC "")
 
 # Enabled KTX1 Only
 file(GLOB_RECURSE KTX_Lib

--- a/applications/_plugins/cimage/ktx2/CMakeLists.txt
+++ b/applications/_plugins/cimage/ktx2/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-add_library(Image_KTX2 SHARED "")
+add_library(Image_KTX2 STATIC "")
 
 target_sources(Image_KTX2
     PRIVATE

--- a/applications/_plugins/cimage/tga/CMakeLists.txt
+++ b/applications/_plugins/cimage/tga/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-add_library(Image_TGA SHARED "")
+add_library(Image_TGA STATIC "")
 
 target_sources(Image_TGA
     PRIVATE

--- a/applications/_plugins/common/CMakeLists.txt
+++ b/applications/_plugins/common/CMakeLists.txt
@@ -60,7 +60,7 @@ if (OPTION_BUILD_EXR)
     list(APPEND PLUGIN_COMMON_H   cexr.h)
 endif()
 
-add_library(CMP_Common SHARED
+add_library(CMP_Common STATIC
     ${PLUGIN_COMMON_SRC} 
     ${PLUGIN_COMMON_SRC_QT}
     ${PLUGIN_COMMON_H}

--- a/cmp_core/CMakeLists.txt
+++ b/cmp_core/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-add_library(CMP_Core SHARED)
+add_library(CMP_Core STATIC)
 
 target_sources(CMP_Core
     PRIVATE
@@ -67,7 +67,7 @@ set_target_properties(CMP_Core PROPERTIES FOLDER ${PROJECT_FOLDER_SDK_LIBS})
 # Core SIMD options
 
 # SSE
-add_library(CMP_Core_SSE SHARED)
+add_library(CMP_Core_SSE STATIC)
 target_sources(CMP_Core_SSE PRIVATE source/core_simd_sse.cpp)
 target_include_directories(CMP_Core_SSE PRIVATE source shaders)
 
@@ -78,7 +78,7 @@ endif()
 set_target_properties(CMP_Core_SSE PROPERTIES FOLDER ${PROJECT_FOLDER_SDK_LIBS})
 
 # AVX
-add_library(CMP_Core_AVX SHARED)
+add_library(CMP_Core_AVX STATIC)
 target_sources(CMP_Core_AVX PRIVATE source/core_simd_avx.cpp)
 target_include_directories(CMP_Core_AVX PRIVATE source shaders)
 
@@ -91,7 +91,7 @@ endif()
 set_target_properties(CMP_Core_AVX PROPERTIES FOLDER ${PROJECT_FOLDER_SDK_LIBS})
 
 # AVX-512
-add_library(CMP_Core_AVX512 SHARED)
+add_library(CMP_Core_AVX512 STATIC)
 target_sources(CMP_Core_AVX512 PRIVATE source/core_simd_avx512.cpp)
 target_include_directories(CMP_Core_AVX512 PRIVATE source shaders)
 


### PR DESCRIPTION
For some reason, our previous succcess over in Compressonator.NET was actually somehow wrong. I don't quite know why because I remember everything working. Anyway it stopped working with messaging like this:

![image](https://github.com/user-attachments/assets/744088b4-b27d-47d8-9eee-0b04d533d59d)

Reading these through and debugging for way longer that you would want to know, including with `strace` CMP_Compressonator.so is dependent on CMP_Core.so which is dependent on a whole bunch of files.

The message above is saying that the `[DllImport]` attribute FOUND CMP_Compressonator.so but could not find CMP_Core.

CMP_Core is in the same directory in the Compressonator Build. However, it seems DllImport isn't setup to load other .So files.

SO, on mostly a complete hunch. I backed out the majority of @yoshiyoshyosh's changes to the CMakeLists here. But left the `SHARED` definition changes within two locations: CMP_Compressonator and CMP_Framework.

This new build results in 2 SO files:
![image](https://github.com/user-attachments/assets/2750ad1d-078e-4241-a88e-ad8e5d2c6189)


These SO files now contain their depdencies INSIDE them. So these files now more closely match the Windows Native Libraries.


They also work, as evidenced by this picture which is here to mostly validate my sanity because I swear the old version worked!
![image](https://github.com/user-attachments/assets/00264f8d-7520-4db8-b4cc-9cfc993f17d7)




