### PR TITLE
ARM64 builds

### DIFF
--- a/.github/workflows/build-ydms.yaml
+++ b/.github/workflows/build-ydms.yaml
@@ -5,7 +5,11 @@ on: [push]
 
 jobs:
   build-linux:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        osver: [ubuntu-latest, ubuntu-24.04-arm]
+
+    runs-on: ${{ matrix.osver }}
 
     steps:
       - uses: actions/checkout@v4
@@ -13,6 +17,12 @@ jobs:
         run: |
           echo "wps=${{ github.workspace }}/builddir" >> "$GITHUB_ENV"
           mkdir -p ${{ github.workspace }}/builddir
+
+          if ${{ matrix.osver == 'ubuntu-24.04-arm' }}; then
+            echo "distname=compressonator-linux-arm" >> "$GITHUB_ENV"
+          else
+            echo "distname=compressonator-linux" >> "$GITHUB_ENV"
+          fi
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -20,7 +30,7 @@ jobs:
       - name: Generate build files
         working-directory: ${{ env.wps }}
         run: |
-          cmake -DOPTION_ENABLE_ALL_APPS=OFF -DOPTION_BUILD_CMP_SDK=ON -DOPTION_CMP_QT=OFF -DOPTION_BUILD_KTX2=ON -DOPTION_BUILD_EXR=ON -DOPTION_BUILD_GUI=OFF -DBUILD_SHARED_LIBS=ON ..
+          cmake -DOPTION_ENABLE_ALL_APPS=OFF -DOPTION_BUILD_CMP_SDK=ON -DOPTION_CMP_QT=OFF -DOPTION_BUILD_KTX2=ON -DOPTION_BUILD_EXR=ON -DOPTION_BUILD_GUI=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_CXX_FLAGS="-march=native" ..
       - name: Build library
         working-directory: ${{ env.wps }}
         run: |
@@ -28,7 +38,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: linux-lib
+          name: ${{ env.distname }}
           path: ${{ env.wps }}/lib/**/*.so
 
   build-windows:

--- a/cmp_core/CMakeLists.txt
+++ b/cmp_core/CMakeLists.txt
@@ -66,13 +66,27 @@ set_target_properties(CMP_Core PROPERTIES FOLDER ${PROJECT_FOLDER_SDK_LIBS})
 
 # Core SIMD options
 
+# Check architecture
+include(CheckCXXSourceCompiles)
+check_cxx_source_compiles("
+#if defined(__aarch64__) || defined(_M_ARM64)
+int main() { return 0; }
+#else
+#error not arm64
+#endif
+" CMP_IS_ARM64)
+
 # SSE
 add_library(CMP_Core_SSE STATIC)
 target_sources(CMP_Core_SSE PRIVATE source/core_simd_sse.cpp)
 target_include_directories(CMP_Core_SSE PRIVATE source shaders)
 
 if (UNIX)
-    target_compile_options(CMP_Core_SSE PRIVATE -march=nehalem)
+    if (CMP_IS_ARM64)
+        target_compile_definitions(CMP_Core_SSE PRIVATE CMP_ARM64_BUILD)
+    else()
+        target_compile_options(CMP_Core_SSE PRIVATE -march=nehalem)
+    endif()
 endif()
 
 set_target_properties(CMP_Core_SSE PROPERTIES FOLDER ${PROJECT_FOLDER_SDK_LIBS})
@@ -83,9 +97,17 @@ target_sources(CMP_Core_AVX PRIVATE source/core_simd_avx.cpp)
 target_include_directories(CMP_Core_AVX PRIVATE source shaders)
 
 if (WIN32)
-    target_compile_options(CMP_Core_AVX PRIVATE /arch:AVX2)
+    if (CMP_IS_ARM64)
+        target_compile_definitions(CMP_Core_AVX PRIVATE CMP_ARM64_BUILD)
+    else()
+        target_compile_options(CMP_Core_AVX PRIVATE /arch:AVX2)
+    endif()
 else()
-    target_compile_options(CMP_Core_AVX PRIVATE -march=haswell)
+    if (CMP_IS_ARM64)
+        target_compile_definitions(CMP_Core_AVX PRIVATE CMP_ARM64_BUILD)
+    else()
+        target_compile_options(CMP_Core_AVX PRIVATE -march=haswell)
+    endif()
 endif()
 
 set_target_properties(CMP_Core_AVX PROPERTIES FOLDER ${PROJECT_FOLDER_SDK_LIBS})
@@ -96,9 +118,17 @@ target_sources(CMP_Core_AVX512 PRIVATE source/core_simd_avx512.cpp)
 target_include_directories(CMP_Core_AVX512 PRIVATE source shaders)
 
 if (WIN32)
-    target_compile_options(CMP_Core_AVX512 PRIVATE /arch:AVX-512)
+    if (CMP_IS_ARM64)
+        target_compile_definitions(CMP_Core_AVX512 PRIVATE CMP_ARM64_BUILD)
+    else()
+        target_compile_options(CMP_Core_AVX512 PRIVATE /arch:AVX-512)
+    endif()
 else()
-    target_compile_options(CMP_Core_AVX512 PRIVATE -march=knl)
+    if (CMP_IS_ARM64)
+        target_compile_definitions(CMP_Core_AVX512 PRIVATE CMP_ARM64_BUILD)
+    else()
+        target_compile_options(CMP_Core_AVX512 PRIVATE -march=knl)
+    endif()
 endif()
 
 set_target_properties(CMP_Core_AVX512 PROPERTIES FOLDER ${PROJECT_FOLDER_SDK_LIBS})

--- a/cmp_core/source/core_simd_avx.cpp
+++ b/cmp_core/source/core_simd_avx.cpp
@@ -21,6 +21,25 @@
 //
 //=====================================================================
 
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(CMP_ARM64_BUILD)
+#include <arm_neon.h>
+#include "core_simd.h"
+#include "common_def.h"
+#include "bcn_common_kernel.h"
+
+#if defined(_WIN32) || defined(_WIN64)
+#define ALIGN_32 __declspec(align(32))
+#else
+#define ALIGN_32 __attribute__((aligned(32)))
+#endif
+
+extern CGU_UINT32 CompressBlockBC1(const CGU_UINT8 *srcBlock, CGU_UINT32 srcStrideInBytes, CGU_UINT8 *dst, const CGU_UINT8 *options);
+
+void CompressBlockBC1_RGBA_AVX2(const CMP_Vec4uc srcBlockTemp[16], CMP_GLOBAL CGU_UINT32 compressedBlock[2], CMP_GLOBAL const CGU_UINT8* options) {
+    CompressBlockBC1((CGU_UINT8*)srcBlockTemp, 16, (CGU_UINT8*)compressedBlock, options);
+}
+
+#else
 #include <immintrin.h>
 
 #include "core_simd.h"
@@ -158,3 +177,4 @@ CGU_FLOAT avx_bc1ComputeBestEndpoints(CGU_FLOAT endpointsOut[2],
 
     return minError;
 }
+#endif

--- a/cmp_core/source/core_simd_avx512.cpp
+++ b/cmp_core/source/core_simd_avx512.cpp
@@ -21,6 +21,25 @@
 //
 //=====================================================================
 
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(CMP_ARM64_BUILD)
+#include <arm_neon.h>
+#include "core_simd.h"
+#include "common_def.h"
+#include "bcn_common_kernel.h"
+
+#if defined(_WIN32) || defined(_WIN64)
+#define ALIGN_64 __declspec(align(64))
+#else
+#define ALIGN_64 __attribute__((aligned(64)))
+#endif
+
+extern CGU_UINT32 CompressBlockBC1(const CGU_UINT8 *srcBlock, CGU_UINT32 srcStrideInBytes, CGU_UINT8 *dst, const CGU_UINT8 *options);
+
+void CompressBlockBC1_RGBA_AVX512(const CMP_Vec4uc srcBlockTemp[16], CMP_GLOBAL CGU_UINT32 compressedBlock[2], CMP_GLOBAL const CGU_UINT8* options) {
+    CompressBlockBC1((CGU_UINT8*)srcBlockTemp, 16, (CGU_UINT8*)compressedBlock, options);
+}
+
+#else
 #include <immintrin.h>
 
 #include "core_simd.h"
@@ -136,3 +155,4 @@ CGU_FLOAT avx512_bc1ComputeBestEndpoints(CGU_FLOAT endpointsOut[2],
 
     return minError;
 }
+#endif

--- a/cmp_core/source/core_simd_sse.cpp
+++ b/cmp_core/source/core_simd_sse.cpp
@@ -21,6 +21,25 @@
 //
 //=====================================================================
 
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(CMP_ARM64_BUILD)
+#include <arm_neon.h>
+#include "core_simd.h"
+#include "common_def.h"
+#include "bcn_common_kernel.h"
+
+#if defined(_WIN32) || defined(_WIN64)
+#define ALIGN_16 __declspec(align(16))
+#else
+#define ALIGN_16 __attribute__((aligned(16)))
+#endif
+
+extern CGU_UINT32 CompressBlockBC1(const CGU_UINT8 *srcBlock, CGU_UINT32 srcStrideInBytes, CGU_UINT8 *dst, const CGU_UINT8 *options);
+
+void CompressBlockBC1_RGBA_SSE2(const CMP_Vec4uc srcBlockTemp[16], CMP_GLOBAL CGU_UINT32 compressedBlock[2], CMP_GLOBAL const CGU_UINT8* options) {
+    CompressBlockBC1((CGU_UINT8*)srcBlockTemp, 16, (CGU_UINT8*)compressedBlock, options);
+}
+
+#else
 #include <xmmintrin.h>
 #include <smmintrin.h>
 
@@ -195,3 +214,4 @@ CGU_FLOAT sse_bc1ComputeBestEndpoints(CGU_FLOAT endpointsOut[2],
 
     return minError;
 }
+#endif


### PR DESCRIPTION
From commit:
```
Basically adds a matrix element to the regular Linux build to enable the use of the ubuntu-*-arm runners available on GitHub.

Additionally, I had to patch a few files, notably the CMakeLists.txt that contains extension-specific conditions.

Other extension-specific files were also patched to avoid them throwing an error when building on ARM64.
```

This PR will probably be useful in the future, when MacOS builds are tackled.

Proof:
- https://github.com/jae1911/compressonator-ydms/actions/runs/14810175727/job/41583889898