### PR TITLE
Cleaning up BC6H Fixes

### DIFF
--- a/.github/workflows/build-ydms.yaml
+++ b/.github/workflows/build-ydms.yaml
@@ -66,4 +66,4 @@ jobs:
         with:
           if-no-files-found: error
           name: windows-lib
-          path: results/
+          path: results/**/*.dll

--- a/.github/workflows/build-ydms.yaml
+++ b/.github/workflows/build-ydms.yaml
@@ -60,7 +60,7 @@ jobs:
         shell: bash
         run: |
           mkdir results
-          cp build/Release*/x64/{*.lib,*.dll} results
+          cp build/Release*/x64/**/* results
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-ydms.yaml
+++ b/.github/workflows/build-ydms.yaml
@@ -66,4 +66,4 @@ jobs:
         with:
           if-no-files-found: error
           name: windows-lib
-          path: results/**/*.dll
+          path: results/

--- a/.github/workflows/build-ydms.yaml
+++ b/.github/workflows/build-ydms.yaml
@@ -60,7 +60,7 @@ jobs:
         shell: bash
         run: |
           mkdir results
-          cp -r build/Release*/x64/**/* results
+          cp -r build/Release*/x64/** results
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-ydms.yaml
+++ b/.github/workflows/build-ydms.yaml
@@ -60,7 +60,7 @@ jobs:
         shell: bash
         run: |
           mkdir results
-          cp build/Release*/x64/**/* results
+          cp -r build/Release*/x64/**/* results
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/applications/_plugins/ccmp_sdk/bc6/bc6h.cpp
+++ b/applications/_plugins/ccmp_sdk/bc6/bc6h.cpp
@@ -229,7 +229,6 @@ int BC6H_EncodeClass::CompressBlock(void* in, void* out, void* blockoptions)
 
 int BC6H_EncodeClass::CompressBlock(unsigned int xBlock, unsigned int yBlock, void* srcin, void* cmpout)
 {
-    printf("BC6H_CompressBlock\n");
     CMP_HALF* p_source_pixels = (CMP_HALF*)srcin;
     if ((m_srcHeight == 0) || (m_srcWidth == 0))
     {
@@ -250,15 +249,11 @@ int BC6H_EncodeClass::CompressBlock(unsigned int xBlock, unsigned int yBlock, vo
     unsigned int destI  = (xBlock * COMPRESSED_BLOCK_SIZE) + (yBlock * width_in_blocks * COMPRESSED_BLOCK_SIZE);
     unsigned int srcidx = 0;
 
-    printf("BC6H_CompressBlock - 253\n");
-
     //Check if it is a complete 4X4 block
     if (((xBlock + 1) * BlockX <= m_srcWidth) && ((yBlock + 1) * BlockY <= m_srcHeight))
     {
-        printf("BC6H_CompressBlock - 258\n");
         for (int i = 0; i < BlockX; i++)
         {
-            printf("BC6H_CompressBlock - BlockX Loop %d \n", i);
             srcidx = i * stride;
             for (int j = 0; j < BlockY; j++)
             {

--- a/applications/_plugins/ccmp_sdk/bc6/bc6h.cpp
+++ b/applications/_plugins/ccmp_sdk/bc6/bc6h.cpp
@@ -298,7 +298,6 @@ int BC6H_EncodeClass::CompressBlock(unsigned int xBlock, unsigned int yBlock, vo
     }
     else
     {
-        printf("BC6H_CompressBlock - 300\n");
         CMP_DWORD dwWidth = CMP_MIN(static_cast<unsigned int>(BlockX), m_srcWidth - xBlock * BlockX);  //x block width
         CMP_DWORD i, j, srcIndex;
 
@@ -347,7 +346,7 @@ int BC6H_EncodeClass::CompressBlock(unsigned int xBlock, unsigned int yBlock, vo
         if (j < BlockY)
             PadBlock(j, BlockX, BlockY, 4, (CMP_FLOAT*)BC6HEncode_local.din);
     }
-    printf("BC6H_CompressBlock - 349\n");
+
     CompressBlockBC6_Internal((unsigned char*)cmpout, destI, &BC6HEncode_local, &g_BC6HEncode);
     return (0);
 }

--- a/applications/_plugins/ccmp_sdk/bc6/bc6h.cpp
+++ b/applications/_plugins/ccmp_sdk/bc6/bc6h.cpp
@@ -255,13 +255,18 @@ int BC6H_EncodeClass::CompressBlock(unsigned int xBlock, unsigned int yBlock, vo
     //Check if it is a complete 4X4 block
     if (((xBlock + 1) * BlockX <= m_srcWidth) && ((yBlock + 1) * BlockY <= m_srcHeight))
     {
+        printf("BC6H_CompressBlock - 258\n");
         for (int i = 0; i < BlockX; i++)
         {
+            printf("BC6H_CompressBlock - BlockX Loop %d \n", i);
             srcidx = i * stride;
             for (int j = 0; j < BlockY; j++)
             {
+                printf("BC6H_CompressBlock - BlockY Loop %d \n", j);
                 CMP_HALF srcpix                         = p_source_pixels[srcOffset + srcidx++];
                 BC6HEncode_local.din[i * BlockX + j][0] = (srcpix).bits();
+
+                printf("BC6H_CompressBlock - BlockY Loop %d 269 \n", j);
                 if ((srcpix).isNan() || srcpix < 0.00001f)
                 {
                     if (g_BC6HEncode.m_isSigned)
@@ -270,6 +275,7 @@ int BC6H_EncodeClass::CompressBlock(unsigned int xBlock, unsigned int yBlock, vo
                         BC6HEncode_local.din[i * BlockX + j][0] = 0.0;
                 }
 
+                printf("BC6H_CompressBlock - BlockY Loop %d 278 \n", j);
                 srcpix                                  = p_source_pixels[srcOffset + srcidx++];
                 BC6HEncode_local.din[i * BlockX + j][1] = (srcpix).bits();
                 if ((srcpix).isNan() || srcpix < 0.00001f)
@@ -279,7 +285,7 @@ int BC6H_EncodeClass::CompressBlock(unsigned int xBlock, unsigned int yBlock, vo
                     else
                         BC6HEncode_local.din[i * BlockX + j][1] = 0.0;
                 }
-
+                printf("BC6H_CompressBlock - BlockY Loop %d 288 \n", j);
                 srcpix                                  = p_source_pixels[srcOffset + srcidx++];
                 BC6HEncode_local.din[i * BlockX + j][2] = (srcpix).bits();
                 if ((srcpix).isNan() || srcpix < 0.00001f)
@@ -289,7 +295,7 @@ int BC6H_EncodeClass::CompressBlock(unsigned int xBlock, unsigned int yBlock, vo
                     else
                         BC6HEncode_local.din[i * BlockX + j][2] = 0.0;
                 }
-
+                printf("BC6H_CompressBlock - BlockY Loop %d 298 \n", j);
                 BC6HEncode_local.din[i * BlockX + j][3] = 0.0;  //force alpha channel to 0.0 as bc6 does not process alpha channel
                 srcidx++;                                       //skip alpha channel
             }

--- a/applications/_plugins/ccmp_sdk/bc6/bc6h.cpp
+++ b/applications/_plugins/ccmp_sdk/bc6/bc6h.cpp
@@ -258,6 +258,9 @@ int BC6H_EncodeClass::CompressBlock(unsigned int xBlock, unsigned int yBlock, vo
             for (int j = 0; j < BlockY; j++)
             {
                 CMP_HALF srcpix                         = p_source_pixels[srcOffset + srcidx++];
+                if (srcpix == NULL)
+                    continue;
+
                 BC6HEncode_local.din[i * BlockX + j][0] = (srcpix).bits();
 
                 if ((srcpix).isNan() || srcpix < 0.00001f)

--- a/applications/_plugins/ccmp_sdk/bc6/bc6h.cpp
+++ b/applications/_plugins/ccmp_sdk/bc6/bc6h.cpp
@@ -256,6 +256,7 @@ int BC6H_EncodeClass::CompressBlock(unsigned int xBlock, unsigned int yBlock, vo
             srcidx = i * stride;
             for (int j = 0; j < BlockY; j++)
             {
+                // R
                 CMP_HALF srcpix                         = p_source_pixels[srcOffset + srcidx++];
                 if (srcpix == NULL)
                     continue;
@@ -270,6 +271,7 @@ int BC6H_EncodeClass::CompressBlock(unsigned int xBlock, unsigned int yBlock, vo
                         BC6HEncode_local.din[i * BlockX + j][0] = 0.0;
                 }
 
+                // G
                 srcpix                                  = p_source_pixels[srcOffset + srcidx++];
                 BC6HEncode_local.din[i * BlockX + j][1] = (srcpix).bits();
                 if ((srcpix).isNan() || srcpix < 0.00001f)
@@ -280,6 +282,7 @@ int BC6H_EncodeClass::CompressBlock(unsigned int xBlock, unsigned int yBlock, vo
                         BC6HEncode_local.din[i * BlockX + j][1] = 0.0;
                 }
 
+                // B
                 srcpix                                  = p_source_pixels[srcOffset + srcidx++];
                 BC6HEncode_local.din[i * BlockX + j][2] = (srcpix).bits();
                 if ((srcpix).isNan() || srcpix < 0.00001f)
@@ -290,6 +293,7 @@ int BC6H_EncodeClass::CompressBlock(unsigned int xBlock, unsigned int yBlock, vo
                         BC6HEncode_local.din[i * BlockX + j][2] = 0.0;
                 }
 
+                // A
                 BC6HEncode_local.din[i * BlockX + j][3] = 0.0;  //force alpha channel to 0.0 as bc6 does not process alpha channel
                 srcidx++;                                       //skip alpha channel
             }

--- a/applications/_plugins/ccmp_sdk/bc6/bc6h.cpp
+++ b/applications/_plugins/ccmp_sdk/bc6/bc6h.cpp
@@ -160,6 +160,7 @@ int BC6H_EncodeClass::DecompressBlock(unsigned int xBlock, unsigned int yBlock, 
 
 int BC6H_EncodeClass::CompressTexture(void* srcin, void* cmpout, void* processOptions)
 {
+    printf("BC6H_EncodeClass\n");
     // ToDo: Implement texture level compression
     if (processOptions == NULL)
         return -1;
@@ -228,6 +229,7 @@ int BC6H_EncodeClass::CompressBlock(void* in, void* out, void* blockoptions)
 
 int BC6H_EncodeClass::CompressBlock(unsigned int xBlock, unsigned int yBlock, void* srcin, void* cmpout)
 {
+    printf("BC6H_CompressBlock\n");
     CMP_HALF* p_source_pixels = (CMP_HALF*)srcin;
     if ((m_srcHeight == 0) || (m_srcWidth == 0))
     {
@@ -247,6 +249,8 @@ int BC6H_EncodeClass::CompressBlock(unsigned int xBlock, unsigned int yBlock, vo
 
     unsigned int destI  = (xBlock * COMPRESSED_BLOCK_SIZE) + (yBlock * width_in_blocks * COMPRESSED_BLOCK_SIZE);
     unsigned int srcidx = 0;
+
+    printf("BC6H_CompressBlock - 253\n");
 
     //Check if it is a complete 4X4 block
     if (((xBlock + 1) * BlockX <= m_srcWidth) && ((yBlock + 1) * BlockY <= m_srcHeight))
@@ -293,6 +297,7 @@ int BC6H_EncodeClass::CompressBlock(unsigned int xBlock, unsigned int yBlock, vo
     }
     else
     {
+        printf("BC6H_CompressBlock - 300\n");
         CMP_DWORD dwWidth = CMP_MIN(static_cast<unsigned int>(BlockX), m_srcWidth - xBlock * BlockX);  //x block width
         CMP_DWORD i, j, srcIndex;
 
@@ -341,7 +346,7 @@ int BC6H_EncodeClass::CompressBlock(unsigned int xBlock, unsigned int yBlock, vo
         if (j < BlockY)
             PadBlock(j, BlockX, BlockY, 4, (CMP_FLOAT*)BC6HEncode_local.din);
     }
-
+    printf("BC6H_CompressBlock - 349\n");
     CompressBlockBC6_Internal((unsigned char*)cmpout, destI, &BC6HEncode_local, &g_BC6HEncode);
     return (0);
 }

--- a/applications/_plugins/ccmp_sdk/bc6/bc6h.cpp
+++ b/applications/_plugins/ccmp_sdk/bc6/bc6h.cpp
@@ -262,11 +262,9 @@ int BC6H_EncodeClass::CompressBlock(unsigned int xBlock, unsigned int yBlock, vo
             srcidx = i * stride;
             for (int j = 0; j < BlockY; j++)
             {
-                printf("BC6H_CompressBlock - BlockY Loop %d \n", j);
                 CMP_HALF srcpix                         = p_source_pixels[srcOffset + srcidx++];
                 BC6HEncode_local.din[i * BlockX + j][0] = (srcpix).bits();
 
-                printf("BC6H_CompressBlock - BlockY Loop %d 269 \n", j);
                 if ((srcpix).isNan() || srcpix < 0.00001f)
                 {
                     if (g_BC6HEncode.m_isSigned)
@@ -275,7 +273,6 @@ int BC6H_EncodeClass::CompressBlock(unsigned int xBlock, unsigned int yBlock, vo
                         BC6HEncode_local.din[i * BlockX + j][0] = 0.0;
                 }
 
-                printf("BC6H_CompressBlock - BlockY Loop %d 278 \n", j);
                 srcpix                                  = p_source_pixels[srcOffset + srcidx++];
                 BC6HEncode_local.din[i * BlockX + j][1] = (srcpix).bits();
                 if ((srcpix).isNan() || srcpix < 0.00001f)
@@ -285,7 +282,7 @@ int BC6H_EncodeClass::CompressBlock(unsigned int xBlock, unsigned int yBlock, vo
                     else
                         BC6HEncode_local.din[i * BlockX + j][1] = 0.0;
                 }
-                printf("BC6H_CompressBlock - BlockY Loop %d 288 \n", j);
+
                 srcpix                                  = p_source_pixels[srcOffset + srcidx++];
                 BC6HEncode_local.din[i * BlockX + j][2] = (srcpix).bits();
                 if ((srcpix).isNan() || srcpix < 0.00001f)
@@ -295,7 +292,7 @@ int BC6H_EncodeClass::CompressBlock(unsigned int xBlock, unsigned int yBlock, vo
                     else
                         BC6HEncode_local.din[i * BlockX + j][2] = 0.0;
                 }
-                printf("BC6H_CompressBlock - BlockY Loop %d 298 \n", j);
+
                 BC6HEncode_local.din[i * BlockX + j][3] = 0.0;  //force alpha channel to 0.0 as bc6 does not process alpha channel
                 srcidx++;                                       //skip alpha channel
             }

--- a/applications/_plugins/ccmp_sdk/bc6/bc6h.cpp
+++ b/applications/_plugins/ccmp_sdk/bc6/bc6h.cpp
@@ -258,9 +258,6 @@ int BC6H_EncodeClass::CompressBlock(unsigned int xBlock, unsigned int yBlock, vo
             {
                 // R
                 CMP_HALF srcpix                         = p_source_pixels[srcOffset + srcidx++];
-                if (srcpix == NULL)
-                    continue;
-
                 BC6HEncode_local.din[i * BlockX + j][0] = (srcpix).bits();
 
                 if ((srcpix).isNan() || srcpix < 0.00001f)

--- a/applications/_plugins/ccmp_sdk/bc6/bc6h.cpp
+++ b/applications/_plugins/ccmp_sdk/bc6/bc6h.cpp
@@ -160,7 +160,6 @@ int BC6H_EncodeClass::DecompressBlock(unsigned int xBlock, unsigned int yBlock, 
 
 int BC6H_EncodeClass::CompressTexture(void* srcin, void* cmpout, void* processOptions)
 {
-    printf("BC6H_EncodeClass\n");
     // ToDo: Implement texture level compression
     if (processOptions == NULL)
         return -1;

--- a/build_sdk/cmp_framework.vcxproj
+++ b/build_sdk/cmp_framework.vcxproj
@@ -179,6 +179,7 @@
     <RootNamespace>CompressonatorLib</RootNamespace>
     <ProjectName>CMP_Framework</ProjectName>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <DebugSymbols>All</DebugSymbols>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)/Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -1147,6 +1148,8 @@
       <StringPooling>true</StringPooling>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <ProgramDataBaseFileName>$(OutDir)$(ProjectName)_MD_DLL.pdb</ProgramDataBaseFileName>
+      <DebugSymbols>All</DebugSymbols>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/build_sdk/cmp_framework.vcxproj
+++ b/build_sdk/cmp_framework.vcxproj
@@ -279,6 +279,8 @@
     <WholeProgramOptimization>false</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v142</PlatformToolset>
+    <DebugSymbols>All</DebugSymbols>
+    <DebugType>Full</DebugType>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release_MD|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
@@ -293,6 +295,8 @@
     <WholeProgramOptimization>false</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
     <PlatformToolset>v142</PlatformToolset>
+    <DebugSymbols>All</DebugSymbols>
+    <DebugType>Full</DebugType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)/Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -1147,6 +1151,8 @@
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <StringPooling>true</StringPooling>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <DebugType>full</DebugType>
+      <PdbFile>$(OutDir)$(ProjectName)_MD_DLL.pdb</PdbFile>
       <ProgramDataBaseFileName>$(OutDir)$(ProjectName)_MD_DLL.pdb</ProgramDataBaseFileName>
       <DebugSymbols>All</DebugSymbols>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/cmp_compressonatorlib/bc6h/codec_bc6h.cpp
+++ b/cmp_compressonatorlib/bc6h/codec_bc6h.cpp
@@ -273,6 +273,8 @@ CodecError CCodec_BC6H::CInitializeBC6HLibrary()
     DbgTrace("BC6H Encoding Quality: %f\n", m_fQuality);
 #endif
 
+    printf("Initialize BC6H Library: %d\n", m_NumEncodingThreads);
+
     for (int i = 0; i < m_NumEncodingThreads; i++)
     {
         // Create single encoder instance

--- a/cmp_compressonatorlib/bc6h/codec_bc6h.cpp
+++ b/cmp_compressonatorlib/bc6h/codec_bc6h.cpp
@@ -273,8 +273,6 @@ CodecError CCodec_BC6H::CInitializeBC6HLibrary()
     DbgTrace("BC6H Encoding Quality: %f\n", m_fQuality);
 #endif
 
-    printf("Initialize BC6H Library: %d\n", m_NumEncodingThreads);
-
     for (int i = 0; i < m_NumEncodingThreads; i++)
     {
         // Create single encoder instance

--- a/cmp_compressonatorlib/bc6h/codec_bc6h.cpp
+++ b/cmp_compressonatorlib/bc6h/codec_bc6h.cpp
@@ -181,28 +181,31 @@ CCodec_BC6H::~CCodec_BC6H()
             m_EncodeParameterStorage[i].exit = TRUE;
     }
 
-
-    for (DWORD dwThread = 0; dwThread < m_LiveThreads; dwThread++)
+    if (m_EncodingThreadHandle != NULL)
     {
-        std::thread& curThread = m_EncodingThreadHandle[dwThread];
+        for (DWORD dwThread = 0; dwThread < m_LiveThreads; dwThread++)
+        {
+            std::thread& curThread = m_EncodingThreadHandle[dwThread];
+            curThread.join();
+        }
 
-        curThread.join();
+        for (unsigned int i = 0; i < m_LiveThreads; i++)
+        {
+            std::thread& curThread = m_EncodingThreadHandle[i];
+
+            curThread = std::thread();
+        }
+
+        // Clear storage of threads
+        delete[] m_EncodingThreadHandle;
+        m_EncodingThreadHandle = NULL;
     }
-
-    for (unsigned int i = 0; i < m_LiveThreads; i++)
-    {
-        std::thread& curThread = m_EncodingThreadHandle[i];
-
-        curThread = std::thread();
-    }
-
-    // Clear storage of threads
-    delete[] m_EncodingThreadHandle;
-    m_EncodingThreadHandle = NULL;
 
     if (m_EncodeParameterStorage)
+    {
         delete[] m_EncodeParameterStorage;
-    m_EncodeParameterStorage = NULL;
+        m_EncodeParameterStorage = NULL;
+    }
 
     // Delete encoders
     for (int i = 0; i < m_NumEncodingThreads; i++)
@@ -290,12 +293,14 @@ CodecError CCodec_BC6H::CInitializeBC6HLibrary()
                 delete[] m_EncodeParameterStorage;
             m_EncodeParameterStorage = NULL;
 
-            delete[] m_EncodingThreadHandle;
+            if (m_EncodingThreadHandle)
+                delete[] m_EncodingThreadHandle;
             m_EncodingThreadHandle = NULL;
 
             for (int j = 0; j < i; j++)
             {
-                delete m_encoder[j];
+                if (m_encoder[j])
+                    delete m_encoder[j];
                 m_encoder[j] = NULL;
             }
 
@@ -391,9 +396,10 @@ CodecError CCodec_BC6H::CEncodeBC6HBlock(float in[MAX_SUBSET_SIZE][MAX_DIMENSION
 CodecError CCodec_BC6H::CFinishBC6HEncoding(void)
 {
     if (!m_LibraryInitialized)
-    {
         return CE_Unknown;
-    }
+    
+    if (!m_EncodeParameterStorage)
+        return CE_OK;
     
     // Wait for all the live threads to finish any current work
     for (DWORD i = 0; i < m_LiveThreads; i++)

--- a/cmp_compressonatorlib/bc6h/codec_bc6h.cpp
+++ b/cmp_compressonatorlib/bc6h/codec_bc6h.cpp
@@ -341,6 +341,8 @@ CodecError CCodec_BC6H::CInitializeBC6HLibrary()
     }
 
     m_LibraryInitialized = true;
+
+    return CE_OK;
 }
 
 CodecError CCodec_BC6H::CEncodeBC6HBlock(float in[MAX_SUBSET_SIZE][MAX_DIMENSION_BIG], BYTE* out)

--- a/cmp_core/shaders/bc6_encode_kernel.cpp
+++ b/cmp_core/shaders/bc6_encode_kernel.cpp
@@ -3512,6 +3512,8 @@ void CompressBlockBC6_Internal(CMP_GLOBAL unsigned char*     outdata,
         BC6HEncode_local->d_shape_index = bestShape;
     }
 
+    printf("BC6H_CompressBlock - 3515\n");
+
     // run through 32 possible partition set
     for (CGU_INT8 shape = 0; shape < MAX_BC6H_PARTITIONS; shape++)
     {
@@ -3540,7 +3542,7 @@ void CompressBlockBC6_Internal(CMP_GLOBAL unsigned char*     outdata,
             }
         }
     }
-
+    printf("BC6H_compressblock  - 3545\n");
     bestError = EncodePattern(BC6HEncode_local, bestError);
 
     // used for debugging modes, set the value you want to debug with

--- a/cmp_core/shaders/bc6_encode_kernel.cpp
+++ b/cmp_core/shaders/bc6_encode_kernel.cpp
@@ -3512,8 +3512,6 @@ void CompressBlockBC6_Internal(CMP_GLOBAL unsigned char*     outdata,
         BC6HEncode_local->d_shape_index = bestShape;
     }
 
-    printf("BC6H_CompressBlock - 3515\n");
-
     // run through 32 possible partition set
     for (CGU_INT8 shape = 0; shape < MAX_BC6H_PARTITIONS; shape++)
     {
@@ -3542,7 +3540,7 @@ void CompressBlockBC6_Internal(CMP_GLOBAL unsigned char*     outdata,
             }
         }
     }
-    printf("BC6H_compressblock  - 3545\n");
+
     bestError = EncodePattern(BC6HEncode_local, bestError);
 
     // used for debugging modes, set the value you want to debug with

--- a/cmp_framework/CMakeLists.txt
+++ b/cmp_framework/CMakeLists.txt
@@ -7,6 +7,7 @@ if(CMP_HOST_WINDOWS)
     target_compile_definitions(CMP_Framework PUBLIC
         -DCMP_USE_XMMINTRIN
     )
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 endif()
 
 file(GLOB_RECURSE HALF_SRC

--- a/cmp_framework/compute_base.cpp
+++ b/cmp_framework/compute_base.cpp
@@ -498,8 +498,9 @@ CMP_ERROR CMP_API CMP_ProcessTexture(CMP_MipSet* srcMipSet, CMP_MipSet* dstMipSe
             destTexture.dwWidth      = pInMipLevel->m_nWidth;
             destTexture.dwHeight     = pInMipLevel->m_nHeight;
             destTexture.dwPitch      = 0;
-            destTexture.nBlockWidth  = srcMipSet->m_nBlockWidth;
-            destTexture.nBlockHeight = srcMipSet->m_nBlockHeight;
+            destTexture.nBlockWidth  = dstMipSet->m_nBlockWidth;
+            destTexture.nBlockHeight = dstMipSet->m_nBlockHeight;
+            destTexture.nBlockDepth  = dstMipSet->m_nBlockDepth;
             destTexture.format       = dstMipSet->m_format;
             destTexture.dwDataSize   = CMP_CalculateBufferSize(&destTexture);
 
@@ -528,9 +529,6 @@ CMP_ERROR CMP_API CMP_ProcessTexture(CMP_MipSet* srcMipSet, CMP_MipSet* dstMipSe
             ComputeOptions options;
             options.force_rebuild = false;  // set this to true if you want the shader source code  to be allways compiled!
 
-            printf("Hello just before CMP_CreateComputeLibrary\n");
-            printf("Mip: %d Format: %d", nMipLevel, dstMipSet->m_format);
-
             //===============================================================================
             // Initalize the  Pipeline that will be used for the codec to run on HPC or GPU
             //===============================================================================
@@ -556,8 +554,6 @@ CMP_ERROR CMP_API CMP_ProcessTexture(CMP_MipSet* srcMipSet, CMP_MipSet* dstMipSe
                 return CMP_ERR_FAILED_HOST_SETUP;
             }
 
-            printf("Hello just before CMP_CompressTexture\n");
-
             // Do the compression
             if (CMP_CompressTexture(&kernelOptions, *srcMipSet, *dstMipSet, pFeedbackProc) != CMP_OK)
             {
@@ -567,8 +563,6 @@ CMP_ERROR CMP_API CMP_ProcessTexture(CMP_MipSet* srcMipSet, CMP_MipSet* dstMipSe
                 cmp_mutex.unlock();
                 return CMP_ERR_FAILED_HOST_SETUP;
             }
-
-            printf("Hello just after CMP_CompressTexture\n");
 
             // Get Performance Stats
             if (kernelOptions.getPerfStats)
@@ -581,14 +575,12 @@ CMP_ERROR CMP_API CMP_ProcessTexture(CMP_MipSet* srcMipSet, CMP_MipSet* dstMipSe
             // Close the Pipeline with option to cache as needed
             //===============================================================================
             CMP_DestroyComputeLibrary(true);
-            printf("DESTROY LIBRARY\n");
         }
     }
 
     //if (pFeedbackProc)
     //    pFeedbackProc(100, NULL, NULL);
 
-    printf("MUTEX\n");
     cmp_mutex.unlock();
     return CMP_OK;
 }

--- a/cmp_framework/compute_base.cpp
+++ b/cmp_framework/compute_base.cpp
@@ -421,6 +421,7 @@ std::mutex cmp_mutex;
 
 CMP_ERROR CMP_API CMP_ProcessTexture(CMP_MipSet* srcMipSet, CMP_MipSet* dstMipSet, KernelOptions kernelOptions, CMP_Feedback_Proc pFeedbackProc)
 {
+    printf("init");
     cmp_mutex.lock();
 
     CMP_CMIPS CMips;
@@ -434,6 +435,7 @@ CMP_ERROR CMP_API CMP_ProcessTexture(CMP_MipSet* srcMipSet, CMP_MipSet* dstMipSe
     dstMipSet->m_format  = kernelOptions.format;
     dstMipSet->m_nHeight = srcMipSet->m_nHeight;
     dstMipSet->m_nWidth  = srcMipSet->m_nWidth;
+    printf("FORMAT 2FOURCC");
     CMP_Format2FourCC(dstMipSet->m_format, dstMipSet);
 
     //=====================================================
@@ -456,11 +458,15 @@ CMP_ERROR CMP_API CMP_ProcessTexture(CMP_MipSet* srcMipSet, CMP_MipSet* dstMipSe
         return CMP_ERR_MEM_ALLOC_FOR_MIPSET;
     }
 
+    printf("AFTER ALLOCATE");
+
     CMP_Texture srcTexture;
     srcTexture.dwSize = sizeof(srcTexture);
     int DestMipLevel  = srcMipSet->m_nMipLevels;
 
     dstMipSet->m_nMipLevels = DestMipLevel;
+
+    printf("MIPLOOOOOP");
 
     for (int nMipLevel = 0; nMipLevel < DestMipLevel; nMipLevel++)
     {
@@ -524,6 +530,8 @@ CMP_ERROR CMP_API CMP_ProcessTexture(CMP_MipSet* srcMipSet, CMP_MipSet* dstMipSe
             ComputeOptions options;
             options.force_rebuild = false;  // set this to true if you want the shader source code  to be allways compiled!
 
+            printf("Hello just before CMP_CreateComputeLibrary");
+
             //===============================================================================
             // Initalize the  Pipeline that will be used for the codec to run on HPC or GPU
             //===============================================================================
@@ -548,6 +556,7 @@ CMP_ERROR CMP_API CMP_ProcessTexture(CMP_MipSet* srcMipSet, CMP_MipSet* dstMipSe
                 cmp_mutex.unlock();
                 return CMP_ERR_FAILED_HOST_SETUP;
             }
+            printf("Hello just before CMP_CompressTexture");
 
             // Do the compression
             if (CMP_CompressTexture(&kernelOptions, *srcMipSet, *dstMipSet, pFeedbackProc) != CMP_OK)
@@ -558,6 +567,8 @@ CMP_ERROR CMP_API CMP_ProcessTexture(CMP_MipSet* srcMipSet, CMP_MipSet* dstMipSe
                 cmp_mutex.unlock();
                 return CMP_ERR_FAILED_HOST_SETUP;
             }
+
+            printf("Hello just after CMP_CompressTexture");
 
             // Get Performance Stats
             if (kernelOptions.getPerfStats)
@@ -570,12 +581,14 @@ CMP_ERROR CMP_API CMP_ProcessTexture(CMP_MipSet* srcMipSet, CMP_MipSet* dstMipSe
             // Close the Pipeline with option to cache as needed
             //===============================================================================
             CMP_DestroyComputeLibrary(true);
+            printf("DESTROY LIBRARY");
         }
     }
 
     //if (pFeedbackProc)
     //    pFeedbackProc(100, NULL, NULL);
 
+    printf("MUTEX");
     cmp_mutex.unlock();
     return CMP_OK;
 }

--- a/cmp_framework/compute_base.cpp
+++ b/cmp_framework/compute_base.cpp
@@ -421,7 +421,7 @@ std::mutex cmp_mutex;
 
 CMP_ERROR CMP_API CMP_ProcessTexture(CMP_MipSet* srcMipSet, CMP_MipSet* dstMipSet, KernelOptions kernelOptions, CMP_Feedback_Proc pFeedbackProc)
 {
-    printf("init");
+    printf("init\n");
     cmp_mutex.lock();
 
     CMP_CMIPS CMips;
@@ -435,7 +435,7 @@ CMP_ERROR CMP_API CMP_ProcessTexture(CMP_MipSet* srcMipSet, CMP_MipSet* dstMipSe
     dstMipSet->m_format  = kernelOptions.format;
     dstMipSet->m_nHeight = srcMipSet->m_nHeight;
     dstMipSet->m_nWidth  = srcMipSet->m_nWidth;
-    printf("FORMAT 2FOURCC");
+    printf("FORMAT 2FOURCC\n");
     CMP_Format2FourCC(dstMipSet->m_format, dstMipSet);
 
     //=====================================================
@@ -458,7 +458,7 @@ CMP_ERROR CMP_API CMP_ProcessTexture(CMP_MipSet* srcMipSet, CMP_MipSet* dstMipSe
         return CMP_ERR_MEM_ALLOC_FOR_MIPSET;
     }
 
-    printf("AFTER ALLOCATE");
+    printf("AFTER ALLOCATE\n");
 
     CMP_Texture srcTexture;
     srcTexture.dwSize = sizeof(srcTexture);
@@ -466,7 +466,7 @@ CMP_ERROR CMP_API CMP_ProcessTexture(CMP_MipSet* srcMipSet, CMP_MipSet* dstMipSe
 
     dstMipSet->m_nMipLevels = DestMipLevel;
 
-    printf("MIPLOOOOOP");
+    printf("MIPLOOOOOP\n");
 
     for (int nMipLevel = 0; nMipLevel < DestMipLevel; nMipLevel++)
     {
@@ -530,14 +530,15 @@ CMP_ERROR CMP_API CMP_ProcessTexture(CMP_MipSet* srcMipSet, CMP_MipSet* dstMipSe
             ComputeOptions options;
             options.force_rebuild = false;  // set this to true if you want the shader source code  to be allways compiled!
 
-            printf("Hello just before CMP_CreateComputeLibrary");
+            printf("Hello just before CMP_CreateComputeLibrary\n");
+            printf("Mip: %d Format: %d", nMipLevel, dstMipSet->m_format);
 
             //===============================================================================
             // Initalize the  Pipeline that will be used for the codec to run on HPC or GPU
             //===============================================================================
             if (CMP_CreateComputeLibrary(srcMipSet, &kernelOptions, &CMips) != CMP_OK)
             {
-                PrintInfo("Failed to init HOST Lib. CPU will be used for compression\n");
+                printf("Failed to init HOST Lib. CPU will be used for compression\n");
                 cmp_mutex.unlock();
                 return CMP_ERR_FAILED_HOST_SETUP;
             }
@@ -552,43 +553,43 @@ CMP_ERROR CMP_API CMP_ProcessTexture(CMP_MipSet* srcMipSet, CMP_MipSet* dstMipSe
             if (CMP_SetComputeOptions(&options) != CMP_OK)
             {
                 CMP_DestroyComputeLibrary(true);
-                PrintInfo("Failed to setup SPMD GPU options\n");
+                printf("Failed to setup SPMD GPU options\n");
                 cmp_mutex.unlock();
                 return CMP_ERR_FAILED_HOST_SETUP;
             }
-            printf("Hello just before CMP_CompressTexture");
+            printf("Hello just before CMP_CompressTexture\n");
 
             // Do the compression
             if (CMP_CompressTexture(&kernelOptions, *srcMipSet, *dstMipSet, pFeedbackProc) != CMP_OK)
             {
                 CMips.FreeMipSet(dstMipSet);
                 CMP_DestroyComputeLibrary(true);
-                PrintInfo("Failed to run compute plugin: CPU will be used for compression.\n");
+                printf("Failed to run compute plugin: CPU will be used for compression.\n");
                 cmp_mutex.unlock();
                 return CMP_ERR_FAILED_HOST_SETUP;
             }
 
-            printf("Hello just after CMP_CompressTexture");
+            printf("Hello just after CMP_CompressTexture\n");
 
             // Get Performance Stats
             if (kernelOptions.getPerfStats)
             {
                 if (CMP_GetPerformanceStats(&kernelOptions.perfStats) != CMP_OK)
-                    PrintInfo("Warning unable to get compute plugin performance stats\n");
+                    printf("Warning unable to get compute plugin performance stats\n");
             }
 
             //===============================================================================
             // Close the Pipeline with option to cache as needed
             //===============================================================================
             CMP_DestroyComputeLibrary(true);
-            printf("DESTROY LIBRARY");
+            printf("DESTROY LIBRARY\n");
         }
     }
 
     //if (pFeedbackProc)
     //    pFeedbackProc(100, NULL, NULL);
 
-    printf("MUTEX");
+    printf("MUTEX\n");
     cmp_mutex.unlock();
     return CMP_OK;
 }

--- a/cmp_framework/compute_base.cpp
+++ b/cmp_framework/compute_base.cpp
@@ -389,8 +389,6 @@ CMP_ERROR CMP_API CMP_CompressTexture(KernelOptions* options, CMP_MipSet srcMipS
 {
     CMP_ERROR result;
 
-    printf("CMP_CompressTexture\n");
-
     if (g_ComputeBase)
     {
         result = g_ComputeBase->TC_Compress(options, srcMipSet, dstMipSet, pFeedback);
@@ -423,7 +421,6 @@ std::mutex cmp_mutex;
 
 CMP_ERROR CMP_API CMP_ProcessTexture(CMP_MipSet* srcMipSet, CMP_MipSet* dstMipSet, KernelOptions kernelOptions, CMP_Feedback_Proc pFeedbackProc)
 {
-    printf("init\n");
     cmp_mutex.lock();
 
     CMP_CMIPS CMips;

--- a/cmp_framework/compute_base.cpp
+++ b/cmp_framework/compute_base.cpp
@@ -437,7 +437,7 @@ CMP_ERROR CMP_API CMP_ProcessTexture(CMP_MipSet* srcMipSet, CMP_MipSet* dstMipSe
     dstMipSet->m_format  = kernelOptions.format;
     dstMipSet->m_nHeight = srcMipSet->m_nHeight;
     dstMipSet->m_nWidth  = srcMipSet->m_nWidth;
-    printf("FORMAT 2FOURCC\n");
+
     CMP_Format2FourCC(dstMipSet->m_format, dstMipSet);
 
     //=====================================================
@@ -460,15 +460,11 @@ CMP_ERROR CMP_API CMP_ProcessTexture(CMP_MipSet* srcMipSet, CMP_MipSet* dstMipSe
         return CMP_ERR_MEM_ALLOC_FOR_MIPSET;
     }
 
-    printf("AFTER ALLOCATE\n");
-
     CMP_Texture srcTexture;
     srcTexture.dwSize = sizeof(srcTexture);
     int DestMipLevel  = srcMipSet->m_nMipLevels;
 
     dstMipSet->m_nMipLevels = DestMipLevel;
-
-    printf("MIPLOOOOOP\n");
 
     for (int nMipLevel = 0; nMipLevel < DestMipLevel; nMipLevel++)
     {

--- a/cmp_framework/compute_base.cpp
+++ b/cmp_framework/compute_base.cpp
@@ -556,7 +556,7 @@ CMP_ERROR CMP_API CMP_ProcessTexture(CMP_MipSet* srcMipSet, CMP_MipSet* dstMipSe
             {
                 CMips.FreeMipSet(dstMipSet);
                 CMP_DestroyComputeLibrary(true);
-                PrintInto("Failed to run compute plugin: CPU will be used for compression.\n");
+                PrintInfo("Failed to run compute plugin: CPU will be used for compression.\n");
                 cmp_mutex.unlock();
                 return CMP_ERR_FAILED_HOST_SETUP;
             }

--- a/cmp_framework/compute_base.cpp
+++ b/cmp_framework/compute_base.cpp
@@ -389,6 +389,8 @@ CMP_ERROR CMP_API CMP_CompressTexture(KernelOptions* options, CMP_MipSet srcMipS
 {
     CMP_ERROR result;
 
+    printf("CMP_CompressTexture\n");
+
     if (g_ComputeBase)
     {
         result = g_ComputeBase->TC_Compress(options, srcMipSet, dstMipSet, pFeedback);
@@ -557,6 +559,7 @@ CMP_ERROR CMP_API CMP_ProcessTexture(CMP_MipSet* srcMipSet, CMP_MipSet* dstMipSe
                 cmp_mutex.unlock();
                 return CMP_ERR_FAILED_HOST_SETUP;
             }
+
             printf("Hello just before CMP_CompressTexture\n");
 
             // Do the compression

--- a/cmp_framework/compute_base.cpp
+++ b/cmp_framework/compute_base.cpp
@@ -531,7 +531,7 @@ CMP_ERROR CMP_API CMP_ProcessTexture(CMP_MipSet* srcMipSet, CMP_MipSet* dstMipSe
             //===============================================================================
             if (CMP_CreateComputeLibrary(srcMipSet, &kernelOptions, &CMips) != CMP_OK)
             {
-                printf("Failed to init HOST Lib. CPU will be used for compression\n");
+                PrintInfo("Failed to init HOST Lib. CPU will be used for compression\n");
                 cmp_mutex.unlock();
                 return CMP_ERR_FAILED_HOST_SETUP;
             }
@@ -546,7 +546,7 @@ CMP_ERROR CMP_API CMP_ProcessTexture(CMP_MipSet* srcMipSet, CMP_MipSet* dstMipSe
             if (CMP_SetComputeOptions(&options) != CMP_OK)
             {
                 CMP_DestroyComputeLibrary(true);
-                printf("Failed to setup SPMD GPU options\n");
+                PrintInfo("Failed to setup SPMD GPU options\n");
                 cmp_mutex.unlock();
                 return CMP_ERR_FAILED_HOST_SETUP;
             }
@@ -556,7 +556,7 @@ CMP_ERROR CMP_API CMP_ProcessTexture(CMP_MipSet* srcMipSet, CMP_MipSet* dstMipSe
             {
                 CMips.FreeMipSet(dstMipSet);
                 CMP_DestroyComputeLibrary(true);
-                printf("Failed to run compute plugin: CPU will be used for compression.\n");
+                PrintInto("Failed to run compute plugin: CPU will be used for compression.\n");
                 cmp_mutex.unlock();
                 return CMP_ERR_FAILED_HOST_SETUP;
             }
@@ -565,7 +565,7 @@ CMP_ERROR CMP_API CMP_ProcessTexture(CMP_MipSet* srcMipSet, CMP_MipSet* dstMipSe
             if (kernelOptions.getPerfStats)
             {
                 if (CMP_GetPerformanceStats(&kernelOptions.perfStats) != CMP_OK)
-                    printf("Warning unable to get compute plugin performance stats\n");
+                    PrintInfo("Warning unable to get compute plugin performance stats\n");
             }
 
             //===============================================================================


### PR DESCRIPTION
This addresses a number of issues found while working on/discovering #10 , These items are small and varied but I want to get them into the source because they helped speed things up.

Changes:
1. Label channels in BC6H, helps you immediately figure out whats going on
2. copy all stuff for windows, this allows for PDB files which I need. We'll revisit turning them on/off later
3. PDB stuff in vcproj files.
4. Miscelaneous and ultimately uneeded guards in BC6H. Still good to have.
5. Correcting an annoying issue in Processtexture where the block data wasn't being assigned correctly: https://github.com/Yellow-Dog-Man/compressonator/compare/master...Yellow-Dog-Man:compressonator:prime/debugging-with-print-statements?expand=1#diff-1a2240b747719df9143bbe09451d3d322f6b6e68a0c4940c653b2fb11f6fda70L497