### PR TITLE
fix(linux): wrap m_printInfo stuff in ifdefs,

### DIFF
--- a/cmp_compressonatorlib/compressonator.cpp
+++ b/cmp_compressonatorlib/compressonator.cpp
@@ -612,6 +612,8 @@ CMP_ERROR CMP_API CMP_ConvertMipTexture(CMP_MipSet* p_MipSetIn, CMP_MipSet* p_Mi
 
         for (int nMipLevel = 0; nMipLevel < srcNumMipmapLevels; nMipLevel++)
         {
+
+#ifndef _LINUX
             if (pOptions->m_PrintInfoStr && srcNumMipmapLevels > 1)
             {
                 char buff[256];
@@ -636,6 +638,7 @@ CMP_ERROR CMP_API CMP_ConvertMipTexture(CMP_MipSet* p_MipSetIn, CMP_MipSet* p_Mi
                 srcTexture.dwWidth         = srcMipLevel->m_nWidth;
                 srcTexture.dwHeight        = srcMipLevel->m_nHeight;
                 srcTexture.pData           = srcMipLevel->m_pbData;
+
                 srcTexture.dwDataSize      = CMP_CalculateBufferSize(&srcTexture);
 
                 // Temporary settings
@@ -656,6 +659,7 @@ CMP_ERROR CMP_API CMP_ConvertMipTexture(CMP_MipSet* p_MipSetIn, CMP_MipSet* p_Mi
                 destTexture.nBlockHeight    = p_MipSetIn->m_nBlockHeight;
                 destTexture.format          = pOptions->DestFormat;
                 destTexture.transcodeFormat = p_MipSetOut->m_transcodeFormat;
+
                 destTexture.dwDataSize      = CMP_CalculateBufferSize(&destTexture);
 
                 p_MipSetOut->m_format   = destTexture.format;
@@ -675,6 +679,7 @@ CMP_ERROR CMP_API CMP_ConvertMipTexture(CMP_MipSet* p_MipSetIn, CMP_MipSet* p_Mi
                 destTexture.pData  = pOutMipLevel->m_pbData;
                 p_MipSetOut->pData = pOutMipLevel->m_pbData;
 
+#ifndef _LINUX
                 //==========================
                 // Print info about input
                 //==========================
@@ -693,7 +698,7 @@ CMP_ERROR CMP_API CMP_ConvertMipTexture(CMP_MipSet* p_MipSetIn, CMP_MipSet* p_Mi
                                  srcTexture.dwHeight);
                     pOptions->m_PrintInfoStr(buff);
                 }
-
+#endif
                 // this is needed to preserve the correct initial source size because CMP_ConvertTexture might
                 // edit the srcTexture and change its format into one better suited for processing
                 sourceDataSize = srcTexture.dwDataSize;
@@ -714,7 +719,7 @@ CMP_ERROR CMP_API CMP_ConvertMipTexture(CMP_MipSet* p_MipSetIn, CMP_MipSet* p_Mi
                 {
                     p_MipSetOut->dwDataSize = destTexture.dwDataSize;
                 }
-
+#ifndef _LINUX
                 //==========================
                 // Print info about output
                 //==========================
@@ -729,6 +734,7 @@ CMP_ERROR CMP_API CMP_ConvertMipTexture(CMP_MipSet* p_MipSetIn, CMP_MipSet* p_Mi
                              sourceDataSize / (float)destTexture.dwDataSize);
                     pOptions->m_PrintInfoStr(buff);
                 }
+#endif
             }
         }
     }

--- a/cmp_compressonatorlib/compressonator.cpp
+++ b/cmp_compressonatorlib/compressonator.cpp
@@ -620,6 +620,7 @@ CMP_ERROR CMP_API CMP_ConvertMipTexture(CMP_MipSet* p_MipSetIn, CMP_MipSet* p_Mi
                 snprintf(buff, sizeof(buff), "Processing miplevel %d for texture...\n", nMipLevel);
                 pOptions->m_PrintInfoStr(buff);
             }
+#endif
 
             for (int nFaceOrSlice = 0; nFaceOrSlice < CMP_MaxFacesOrSlices(p_MipSetIn, nMipLevel); nFaceOrSlice++)
             {


### PR DESCRIPTION
m_printInfo stuff is causing issues on Linux.

I think this is a marshaling issue between Linux and windows, but for now disabling it makes sense as we dont use it. I need to get a move on with other things. Will create GH issue.