### PR TITLE
Enhanced Texture Operations

### DIFF
--- a/.github/workflows/build-ydms.yaml
+++ b/.github/workflows/build-ydms.yaml
@@ -61,6 +61,11 @@ jobs:
         run: |
           mkdir results
           cp -r build/Release*/x64/** results
+      # These next 2 steps are a temporary solve for: https://github.com/Yellow-Dog-Man/compressonator/issues/9
+      - name: Adjust CMP_Framework Name
+        run: mv CMP_Framework_MD_DLL.dll CMP_Framework.dll
+      - name: Adjust CMP_Compressonator Name
+        run: mv Compressonator_MD_DLL.dll CMP_Compressonator.dll
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-ydms.yaml
+++ b/.github/workflows/build-ydms.yaml
@@ -63,9 +63,9 @@ jobs:
           cp -r build/Release*/x64/** results
       # These next 2 steps are a temporary solve for: https://github.com/Yellow-Dog-Man/compressonator/issues/9
       - name: Adjust CMP_Framework Name
-        run: mv CMP_Framework_MD_DLL.dll CMP_Framework.dll
+        run: mv results/CMP_Framework_MD_DLL.dll results/CMP_Framework.dll
       - name: Adjust CMP_Compressonator Name
-        run: mv Compressonator_MD_DLL.dll CMP_Compressonator.dll
+        run: mv results/Compressonator_MD_DLL.dll results/CMP_Compressonator.dll
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/applications/_libs/gpu_decode/gpu_decode.cpp
+++ b/applications/_libs/gpu_decode/gpu_decode.cpp
@@ -37,16 +37,16 @@ PluginInterface_GPUDecode* g_GPUDecode_plugin = NULL;
 static CMP_GPUDecode DecodeType = GPUDecode_INVALID;
 
 //
-// CMP_InitializeDecompessLibrary - Initialize the DeCompression library based in GPU Driver support types
+// CMP_InitializeDecompressLibrary - Initialize the DeCompression library based in GPU Driver support types
 //
-CMP_ERROR CMP_API CMP_InitializeDecompessLibrary(CMP_GPUDecode GPUDecodeType, CMP_DWORD Width, CMP_DWORD Height, WNDPROC callback)
+CMP_ERROR CMP_API CMP_InitializeDecompressLibrary(CMP_GPUDecode GPUDecodeType, CMP_DWORD Width, CMP_DWORD Height, WNDPROC callback)
 {
     if (g_GPUDecode_plugin && (DecodeType == GPUDecodeType))
         return CMP_OK;
 
     if (GPUDecodeType != DecodeType)
     {
-        CMP_ShutdownDecompessLibrary();
+        CMP_ShutdownDecompressLibrary();
     }
 
     switch (GPUDecodeType)
@@ -76,9 +76,9 @@ CMP_ERROR CMP_API CMP_InitializeDecompessLibrary(CMP_GPUDecode GPUDecodeType, CM
 }
 
 //
-// CMP_ShutdownDecompessLibrary - Shutdown the DeCompression library
+// CMP_ShutdownDecompressLibrary - Shutdown the DeCompression library
 //
-CMP_ERROR CMP_API CMP_ShutdownDecompessLibrary()
+CMP_ERROR CMP_API CMP_ShutdownDecompressLibrary()
 {
     if (g_GPUDecode_plugin)
     {
@@ -95,7 +95,7 @@ CMP_ERROR CMP_API CMP_DecompressTexture(const CMP_Texture* pSourceTexture, CMP_T
     CMP_ERROR result;
 
     // This is temporary code we should move this into CLI and GUI
-    result = CMP_InitializeDecompessLibrary(GPUDecodeType, pSourceTexture->dwWidth, pSourceTexture->dwHeight, NULL);
+    result = CMP_InitializeDecompressLibrary(GPUDecodeType, pSourceTexture->dwWidth, pSourceTexture->dwHeight, NULL);
     if (result != CMP_OK)
         return (result);
 

--- a/applications/_libs/gpu_decode/gpu_decode.h
+++ b/applications/_libs/gpu_decode/gpu_decode.h
@@ -41,16 +41,16 @@ extern "C" {
 CMP_ERROR CMP_API CMP_DecompressTexture(const CMP_Texture* pSourceTexture, CMP_Texture* pDestTexture, CMP_GPUDecode GPUDecodeType);
 
 //
-/// CMP_InitializeDecompessLibrary - Initialize the DeCompression library based in GPU Driver support types
+/// CMP_InitializeDecompressLibrary - Initialize the DeCompression library based in GPU Driver support types
 /// \return    CMP_OK if successful, otherwise the error code.
 //
-CMP_ERROR CMP_APICMP_InitializeDecompessLibrary(CMP_GPUDecode GPUDecodeType);
+CMP_ERROR CMP_API CMP_InitializeDecompressLibrary(CMP_GPUDecode GPUDecodeType);
 
 //
-/// CMP_ShutdownDecompessLibrary - Shutdown the DeCompression library
+/// CMP_ShutdownDecompressLibrary - Shutdown the DeCompression library
 /// \return    CMP_OK if successful, otherwise the error code.
 //
-CMP_ERROR CMP_API CMP_ShutdownDecompessLibrary();
+CMP_ERROR CMP_API CMP_ShutdownDecompressLibrary();
 #endif
 #ifdef __cplusplus
 };

--- a/applications/compressonatorgui/source/cpmaincomponents.cpp
+++ b/applications/compressonatorgui/source/cpmaincomponents.cpp
@@ -565,7 +565,7 @@ void cpMainComponents::closeEvent(QCloseEvent* event)
     }
 
 #ifdef _WIN32
-    CMP_ShutdownDecompessLibrary();
+    CMP_ShutdownDecompressLibrary();
 #endif
 
     if (m_projectview)
@@ -2647,7 +2647,7 @@ cpMainComponents::~cpMainComponents()
 {
     g_bAbortCompression = true;
 #ifdef _WIN32
-    CMP_ShutdownDecompessLibrary();
+    CMP_ShutdownDecompressLibrary();
 #endif
 }
 

--- a/cmp_compressonatorlib/compressonator.cpp
+++ b/cmp_compressonatorlib/compressonator.cpp
@@ -754,7 +754,7 @@ CMP_ERROR CMP_API CMP_MipSetToTexture(const CMP_MipSet* mipSet, CMP_INT mipLevel
         return CMP_OK;
 
     CMP_MipLevel* mipLevel = 0;
-    CMP_GetMipLevel(&mipLevel, &mipSet, mipLevelIndex, 0);
+    CMP_GetMipLevel(&mipLevel, mipSet, mipLevelIndex, 0);
 
     if (!mipLevel)
         return CMP_OK;

--- a/cmp_compressonatorlib/compressonator.cpp
+++ b/cmp_compressonatorlib/compressonator.cpp
@@ -744,3 +744,38 @@ CMP_ERROR CMP_API CMP_ConvertMipTexture(CMP_MipSet* p_MipSetIn, CMP_MipSet* p_Mi
 
     return CMP_OK;
 }
+
+CMP_ERROR CMP_API CMP_MipSetToTexture(const CMP_MipSet* mipSet, CMP_INT mipLevelIndex, CMP_Texture* pDestTexture) {
+    assert(mipSet);
+    assert(pDestTexture);
+    assert(mipLevelIndex);
+
+    if (mipLevelIndex < 0 || mipLevelIndex >= mipSet->m_nMipLevels)
+        return CMP_OK;
+
+    CMP_MipLevel* mipLevel = 0;
+    CMP_GetMipLevel(&mipLevel, &mipSet, mipLevelIndex, 0);
+
+    if (!mipLevel)
+        return CMP_OK;
+
+    pDestTexture->dwSize = sizeof(CMP_Texture);
+
+    pDestTexture->dwWidth  = mipLevel->m_nWidth;
+    pDestTexture->dwHeight = mipLevel->m_nHeight;
+    pDestTexture->dwPitch  = 0;
+
+    pDestTexture->format          = mipSet->m_format;
+    pDestTexture->transcodeFormat = mipSet->m_transcodeFormat;
+
+    pDestTexture->nBlockWidth  = mipSet->m_nBlockWidth;
+    pDestTexture->nBlockHeight = mipSet->m_nBlockHeight;
+    pDestTexture->nBlockDepth  = mipSet->m_nBlockDepth;
+
+    pDestTexture->dwDataSize = mipLevel->m_dwLinearSize;
+    pDestTexture->pData      = mipLevel->m_pbData;
+
+    pDestTexture->pMipSet = (void*)&mipSet;
+
+    return CMP_OK;
+}

--- a/cmp_compressonatorlib/compressonator.h
+++ b/cmp_compressonatorlib/compressonator.h
@@ -965,6 +965,11 @@ CMP_ERROR CMP_API CMP_ConvertTexture(CMP_Texture*               pSourceTexture,
                                      const CMP_CompressOptions* pOptions,
                                      CMP_Feedback_Proc          pFeedbackProc);
 
+// A basic function that can turn a specific mipmap level of a mipset into a texture object
+// does not handle all cases perfectly
+// Originally found in applications/_plugins/common/cmdline.cpp
+CMP_ERROR CMP_API CMP_MipSetToTexture(const CMP_MipSet* mipSet, CMP_INT mipLevelIndex, CMP_Texture* pDestTexture);
+
 #ifdef __cplusplus
 };
 #endif

--- a/cmp_compressonatorlib/compressonator.h
+++ b/cmp_compressonatorlib/compressonator.h
@@ -1062,6 +1062,12 @@ CMP_ERROR CMP_API CMP_ConvertMipTexture(CMP_MipSet* p_MipSetIn, CMP_MipSet* p_Mi
 //--------------------------------------------
 CMP_ERROR CMP_API  CMP_LoadTexture(const char* sourceFile, CMP_MipSet* pMipSet);
 CMP_ERROR CMP_API  CMP_SaveTexture(const char* destFile, CMP_MipSet* pMipSet);
+/// Saves a CMP_Texture to a file. For simple formats, this is a quick call to stb_image_write. 
+/// For more complex formats, a temporary mip set is created, therefore if you're working with a complex format, it is recommended to work with MipSets Directly.
+/// \param[in] destFile The destination file path
+/// \param[in] pTexture Pointer to the CMP_Texture to save
+/// \return CMP_OK if successful, otherwise an error code
+CMP_ERROR CMP_API  CMP_SaveTextureEx(const char* destFile, CMP_Texture* pTexture);
 CMP_ERROR CMP_API  CMP_ProcessTexture(CMP_MipSet* srcMipSet, CMP_MipSet* dstMipSet, KernelOptions kernelOptions, CMP_Feedback_Proc pFeedbackProc);
 CMP_ERROR CMP_API  CMP_CompressTexture(KernelOptions* options, CMP_MipSet srcMipSet, CMP_MipSet dstMipSet, CMP_Feedback_Proc pFeedback);
 CMP_VOID CMP_API   CMP_Format2FourCC(CMP_FORMAT format, CMP_MipSet* pMipSet);

--- a/cmp_compressonatorlib/compressonatorlib.def
+++ b/cmp_compressonatorlib/compressonatorlib.def
@@ -35,6 +35,7 @@ CMP_MipSetToTexture
 
 CMP_LoadTexture
 CMP_SaveTexture
+CMP_SaveTextureEx
 CMP_ProcessTexture
 CMP_CompressTexture
 CMP_Format2FourCC

--- a/cmp_compressonatorlib/compressonatorlib.def
+++ b/cmp_compressonatorlib/compressonatorlib.def
@@ -31,6 +31,8 @@ CMP_MipSetAnlaysis
 
 CMP_ConvertMipTexture
 
+CMP_MipSetToTexture
+
 CMP_LoadTexture
 CMP_SaveTexture
 CMP_ProcessTexture

--- a/cmp_framework/cmp_framework.def
+++ b/cmp_framework/cmp_framework.def
@@ -7,6 +7,7 @@ CMP_CreateCompressMipSet
 
 CMP_LoadTexture
 CMP_SaveTexture
+CMP_SaveTextureEx
 CMP_ProcessTexture
 CMP_CompressTexture
 CMP_Format2FourCC

--- a/external/stb/stb_image_write.h
+++ b/external/stb/stb_image_write.h
@@ -1134,15 +1134,17 @@ STBIWDEF unsigned char *stbi_write_png_to_mem(const unsigned char *pixels, int s
    signed char *line_buffer;
    int j = 0, zlen = 0;
 
+   int line_buffer_length = x * n;
+
    if (stride_bytes == 0)
-      stride_bytes = x * n;
+      stride_bytes = line_buffer_length;
 
    if (force_filter >= 5) {
       force_filter = -1;
    }
 
-   filt = (unsigned char *) STBIW_MALLOC((x*n+1) * y); if (!filt) return 0;
-   line_buffer = (signed char *) STBIW_MALLOC(x * n); if (!line_buffer) { STBIW_FREE(filt); return 0; }
+   filt = (unsigned char *) STBIW_MALLOC((line_buffer_length+1) * y); if (!filt) return 0;
+   line_buffer = (signed char *) STBIW_MALLOC(line_buffer_length); if (!line_buffer) { STBIW_FREE(filt); return 0; }
    for (j=0; j < y; ++j) {
       int filter_type;
       if (force_filter > -1) {
@@ -1155,8 +1157,11 @@ STBIWDEF unsigned char *stbi_write_png_to_mem(const unsigned char *pixels, int s
 
             // Estimate the entropy of the line using this filter; the less, the better.
             est = 0;
-            for (i = 0; i < x*n; ++i) {
-               est += abs((signed char) line_buffer[i]);
+
+            for (i = 0; i < line_buffer_length; ++i) {
+               if (i < line_buffer_length) {
+                  est += abs((signed char) line_buffer[i]);
+               }
             }
             if (est < best_filter_val) {
                best_filter_val = est;

--- a/external/stb/stb_image_write.h
+++ b/external/stb/stb_image_write.h
@@ -1132,7 +1132,7 @@ STBIWDEF unsigned char *stbi_write_png_to_mem(const unsigned char *pixels, int s
    unsigned char sig[8] = { 137,80,78,71,13,10,26,10 };
    unsigned char *out,*o, *filt, *zlib;
    signed char *line_buffer;
-   int j,zlen;
+   int j = 0, zlen = 0;
 
    if (stride_bytes == 0)
       stride_bytes = x * n;
@@ -1149,7 +1149,7 @@ STBIWDEF unsigned char *stbi_write_png_to_mem(const unsigned char *pixels, int s
          filter_type = force_filter;
          stbiw__encode_png_line((unsigned char*)(pixels), stride_bytes, x, y, j, n, force_filter, line_buffer);
       } else { // Estimate the best filter by running through all of them:
-         int best_filter = 0, best_filter_val = 0x7fffffff, est, i;
+         int best_filter = 0, best_filter_val = 0x7fffffff, est = 0, i = 0;
          for (filter_type = 0; filter_type < 5; filter_type++) {
             stbiw__encode_png_line((unsigned char*)(pixels), stride_bytes, x, y, j, n, filter_type, line_buffer);
 

--- a/gpu_decodelib.def
+++ b/gpu_decodelib.def
@@ -2,6 +2,6 @@
 
 EXPORTS
     CMP_DecompressTexture
-    CMP_InitializeDecompessLibrary
-    CMP_ShutdownDecompessLibrary
+    CMP_InitializeDecompressLibrary
+    CMP_ShutdownDecompressLibrary
 


### PR DESCRIPTION
This drastically improves the interoperability between MipSets and Textures that we have in Compressonator.

- Fixes #18 
- Fixes #17 


1. Adds a version of CMP_SaveTexture that takes a CMP_Texture. To avoid namespace issues this is CMP_SaveTextureEx.
2. Correct all misspellings of: Decompress. This is technically a breaking change.
3. Add CMP_MipSetToTexture which outputs a given mip sets, level as a texture.
4. A partial resoloution to https://github.com/Yellow-Dog-Man/compressonator/issues/9 we'll resolve it properly later.

These changes all have matching tests over in Compressonator.Net.